### PR TITLE
Add architecture section for discovery node

### DIFF
--- a/docs/protocol/discovery-node/_category_.json
+++ b/docs/protocol/discovery-node/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Discovery Node",
+  "position": 3
+}

--- a/docs/protocol/discovery-node/architecture.md
+++ b/docs/protocol/discovery-node/architecture.md
@@ -1,0 +1,59 @@
+---
+sidebar_label: Architecture
+sidebar_position: 2
+---
+
+# Architecture
+
+## Database
+
+The discovery node uses PostgreSQL. Our Postgres database is managed through [SQLAlchemy](https://www.sqlalchemy.org/), an object relational mapper and [Alembic](http://alembic.zzzcomputing.com/en/latest/index.html), a lightweight database migration tool. The data models are defined in [src/models.py](https://github.com/AudiusProject/audius-protocol/blob/master/discovery-provider/src/models.py) which is used by alembic to automatically generate the migrations under [alembic/versions](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider/alembic/versions). You can find the connection defined between alembic and our data models in [alembic/env.py](https://github.com/AudiusProject/audius-discovery-provider/blob/develop/alembic/env.py)
+
+## Flask
+
+The discovery node web server serves as the entrypoint for reading data through the audius protocol. All queries are returned as JSON objects parsed from SQLAlchemy query resultsn, and can be found in [src/queries](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider/src/queries). Some examples of queries include user-specific feeds, track data, playlist data, etc.  
+
+## Celery
+
+Celery is simply a task queue - it allows us to define a set of single tasks repeated throughout the lifetime of the discovery node.
+
+Currently, a single task `(src/tasks/index.py:update_task()`) handles **all database write** operations. The flask application reads from our database and is unaware of data correctness.
+
+Celery **worker** and **beat** are the key underlying concepts behind celery usage in the discovery node. Celery beat is responsible for periodically scheduling index tasks and is run as a separate container from the worker. Details about periodic task scheduling can be found in the [official documentation](http://docs.celeryproject.org/en/latest/userguide/periodic-tasks.html).
+
+Celery worker is the component that actually runs tasks.
+
+### Celery Worker
+
+The primary driver of data availability on audius is the 'index_blocks' celery task.
+What happens when 'index_blocks' is actually executed? The celery task does the following operations:
+
+1. Check whether the latest block is different than the last processed block in the ‘blocks’ table. If so, an array of blocks is generated from the last blockhash present in our database up to the latest block number specified by the block indexing window. 
+    - block indexing window is equivalent to the maximum number of blocks to be processed in a single indexing operation
+2. Traverse over each block in the block array produced after the above step. 
+
+    In each block, check if any transactions relevant to the audius smart contracts are present. If present, we retrieve specific event information from the associated transaction hash - examples include creator and track metadata. To do so, the discovery node *must* be aware of both the contract ABIs as well as each contract's address - these are shipped with each discovery node image. 
+
+3. Given operations from audius contracts in a given block, the task updates the corresponding table in the database. Certain index operations require a metadata fetch from decentralized storage (IPFS - InterPlanetary File System). Metadata formats can be found [here](https://github.com/AudiusProject/audius-protocol/blob/master/discovery-provider/src/tasks/metadata.py). 
+
+*Why index blocks instead of using event filters?*
+
+This is a great question - the main reason we have chosen to index blocks in this manner is to handle cases of false progress and rollback. Each indexing task opens a fresh database session, which means DB transactions can be reverted at a block level - while rollback handling for the discovery node has yet to be implemented, block-level indexing will be immediately useful when it becomes necessary.
+
+### Celery Beat
+
+Identical container as the celery worker but is run as a 'beat scheduler' to ensure indexing is run at a periodic interval. By default this interval is 5 seconds.
+
+## Redis
+
+We use Redis for several things in the discovery node
+
+1. Caching (internally and externally)
+2. As a [broker for Celery](http://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html)
+3. As a mechanism for locking to ensure single execution contexts for Celery jobs
+
+## Elastic Search
+
+Elastic Search is used denormalize data and support certain quries (Feed, Search, Related Artists, etc.). Elastic Search data is populated and kept up to date by database triggers that live on the Postgres database.
+
+ETL code for the Elastic Search layer is found in the [es-indexer](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider/es-indexer).

--- a/docs/protocol/discovery-node/architecture.md
+++ b/docs/protocol/discovery-node/architecture.md
@@ -11,7 +11,7 @@ The discovery node uses PostgreSQL. Our Postgres database is managed through [SQ
 
 ## Flask
 
-The discovery node web server serves as the entrypoint for reading data through the audius protocol. All queries are returned as JSON objects parsed from SQLAlchemy query resultsn, and can be found in [src/queries](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider/src/queries). Some examples of queries include user-specific feeds, track data, playlist data, etc.  
+The discovery node web server serves as the entrypoint for reading data through the audius protocol. All queries are returned as JSON objects parsed from SQLAlchemy query resultsn, and can be found in [src/queries](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider/src/queries). Some examples of queries include user-specific feeds, track data, playlist data, etc.
 
 ## Celery
 
@@ -34,7 +34,7 @@ What happens when 'index_blocks' is actually executed? The celery task does the 
 
     In each block, check if any transactions relevant to the audius smart contracts are present. If present, we retrieve specific event information from the associated transaction hash - examples include creator and track metadata. To do so, the discovery node *must* be aware of both the contract ABIs as well as each contract's address - these are shipped with each discovery node image. 
 
-3. Given operations from audius contracts in a given block, the task updates the corresponding table in the database. Certain index operations require a metadata fetch from decentralized storage (IPFS - InterPlanetary File System). Metadata formats can be found [here](https://github.com/AudiusProject/audius-protocol/blob/master/discovery-provider/src/tasks/metadata.py). 
+3. Given operations from audius contracts in a given block, the task updates the corresponding table in the database. Certain index operations require a metadata fetch from decentralized storage (Audius Storage Protocol). Metadata formats can be found [here](https://github.com/AudiusProject/audius-protocol/blob/master/discovery-provider/src/tasks/metadata.py).
 
 *Why index blocks instead of using event filters?*
 

--- a/docs/protocol/discovery-node/overview.md
+++ b/docs/protocol/discovery-node/overview.md
@@ -1,0 +1,18 @@
+---
+sidebar_label: Overview
+sidebar_position: 1
+---
+
+# Overview
+
+An Audius Discovery Node is a service that indexes the metadata and availability of data across the protocol for Audius users to query. The indexed content includes user, track, and album/playlist information along with social features. The data is stored for quick access, updated on a regular interval, and made available for clients via a RESTful API.
+
+[github repository](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider)
+
+*NOTE - previously the discovery node was also referred to as "discovery provider" or "discovery node". These names all refer to the same service, the discovery node.*
+
+Design Goals
+
+1. Expose queryable endpoints which listeners/creators can interact with
+2. Reliably store relevant blockchain events
+3. Continuously monitor the blockchain and ensure stored data is up to date with the network

--- a/docs/protocol/overview.md
+++ b/docs/protocol/overview.md
@@ -32,19 +32,19 @@ For more details on the Audius architecture, see the [Audius protocol whitepaper
 
 ## Audius Services
 
-| Service | Description |
-| :--- | :--- |
-| [`Content-Node`](https://github.com/AudiusProject/audius-protocol/tree/master/creator-node) | Maintains the availability of users' content on IPFS including user metadata, images, and audio content |
-| [`Discovery-Node`](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider) | Indexes and stores the contents of the Audius contracts on the Ethereum blockchain for clients to query via an API |
-| [`Identity-Service`](https://github.com/AudiusProject/audius-protocol/tree/master/identity-service) | Stores encrypted auth ciphertexts, does Twitter OAuth and relays transactions (pays gas) on behalf of users |
+| Service                                                                                             | Description                                                                                                                    |
+| :-------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------- |
+| [`Content-Node`](https://github.com/AudiusProject/audius-protocol/tree/master/creator-node)         | Maintains the availability of users' content on the Audius Storage Protocol including user metadata, images, and audio content |
+| [`Discovery-Node`](https://github.com/AudiusProject/audius-protocol/tree/master/discovery-provider) | Indexes and stores the contents of the Audius contracts on the Ethereum blockchain for clients to query via an API             |
+| [`Identity-Service`](https://github.com/AudiusProject/audius-protocol/tree/master/identity-service) | Stores encrypted auth ciphertexts, does Twitter OAuth and relays transactions (pays gas) on behalf of users                    |
 
 ## Audius Smart Contracts & Libs
 
-| Lib | Description |
-| :--- | :--- |
-| [`libs`](https://github.com/AudiusProject/audius-protocol/tree/master/libs) | An easy interface to the distributed web and Audius services: Identity Service, Discovery Node \(discovery provider\), Content Node \(creator node\) |
-| [`contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/contracts) | The smart contracts being developed for the Audius streaming protocol |
-| [`eth-contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/eth-contracts) | The Ethereum smart contracts being developed for the Audius streaming protocol |
+| Lib                                                                                           | Description                                                                                                                                          |
+| :-------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`libs`](https://github.com/AudiusProject/audius-protocol/tree/master/libs)                   | An easy interface to the distributed web and Audius services: Identity Service, Discovery Node \(discovery provider\), Content Node \(creator node\) |
+| [`contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/contracts)         | The smart contracts being developed for the Audius streaming protocol                                                                                |
+| [`eth-contracts`](https://github.com/AudiusProject/audius-protocol/tree/master/eth-contracts) | The Ethereum smart contracts being developed for the Audius streaming protocol                                                                       |
 
 ## Service Provider Quickstart
 

--- a/docs/token/running-a-node/introduction.md
+++ b/docs/token/running-a-node/introduction.md
@@ -18,4 +18,4 @@ The Audius protocol is powered by two off-chain services, the Discovery Node and
 **Content Node**
 
 * Hosts audio and image content
-* Syncs content across nodes to ensure data is consistent and highly available \(using IPFS and the Audius Storage Protocol under the hood\)
+* Syncs content across nodes to ensure data is consistent and highly available \(using the Audius Storage Protocol under the hood\)


### PR DESCRIPTION
Primarily lifted from the wiki + added section for elasticsearch.

Docs could use some further clean up & editing.

Will add content node next.